### PR TITLE
Update to marine_acoustic_msgs v2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,12 @@ endif()
 catkin_package(
   INCLUDE_DIRS ${rqt_sonar_image_view_INCLUDE_DIRECTORIES}
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS rqt_gui rqt_gui_cpp image_transport acoustic_msgs cv_bridge geometry_msgs
+  CATKIN_DEPENDS rqt_gui \
+                rqt_gui_cpp \
+                image_transport \
+                marine_acoustic_msgs \
+                cv_bridge \
+                geometry_msgs
 )
 catkin_python_setup()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
               rqt_gui
               rqt_gui_cpp
               image_transport
-              acoustic_msgs
+              marine_acoustic_msgs
               sonar_image_proc
               geometry_msgs
               cv_bridge)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,11 @@ endif()
 catkin_package(
   INCLUDE_DIRS ${rqt_sonar_image_view_INCLUDE_DIRECTORIES}
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS rqt_gui \
-                rqt_gui_cpp \
-                image_transport \
-                marine_acoustic_msgs \
-                cv_bridge \
+  CATKIN_DEPENDS rqt_gui
+                rqt_gui_cpp
+                image_transport
+                marine_acoustic_msgs
+                cv_bridge
                 geometry_msgs
 )
 catkin_python_setup()

--- a/include/rqt_sonar_image_view/image_view.h
+++ b/include/rqt_sonar_image_view/image_view.h
@@ -37,9 +37,9 @@
 #ifndef rqt_sonar_image_view__ImageView_H
 #define rqt_sonar_image_view__ImageView_H
 
-#include <acoustic_msgs/ProjectedSonarImage.h>
 #include <geometry_msgs/Point.h>
 #include <image_transport/image_transport.h>
+#include <marine_acoustic_msgs/ProjectedSonarImage.h>
 #include <ros/macros.h>
 #include <ros/package.h>
 #include <rqt_gui_cpp/plugin.h>
@@ -104,7 +104,7 @@ class ImageView : public rqt_gui_cpp::Plugin {
 
  protected:
   virtual void callbackImage(
-      const acoustic_msgs::ProjectedSonarImage::ConstPtr &msg);
+      const marine_acoustic_msgs::ProjectedSonarImage::ConstPtr &msg);
 
   Ui::ImageViewWidget ui_;
 

--- a/package.xml
+++ b/package.xml
@@ -19,14 +19,14 @@
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_cpp</build_depend>
   <build_depend>sonar_image_proc</build_depend>
-  <build_depend>acoustic_msgs</build_depend>
+  <build_depend>marine_acoustic_msgs</build_depend>
 
   <run_depend>cv_bridge</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>rqt_gui</run_depend>
   <run_depend>rqt_gui_cpp</run_depend>
-  <run_depend>acoustic_msgs</run_depend>
+  <run_depend>marine_acoustic_msgs</run_depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/rqt_sonar_image_view.rosinstall
+++ b/rqt_sonar_image_view.rosinstall
@@ -1,3 +1,2 @@
 - git: {local-name: sonar_image_proc, uri: "https://github.com/apl-ocean-engineering/sonar_image_proc"}
-# - git: {local-name: hydrographic_msgs, uri: "https://github.com/apl-ocean-engineering/hydrographic_msgs.git", version: v0.0.1}
-- git: {local-name: hydrographic_msgs, uri: "https://github.com/apl-ocean-engineering/hydrographic_msgs.git"}
+- git: {local-name: marine_msgs, uri: "https://github.com/apl-ocean-engineering/marine_msgs", version: v2.0.0}

--- a/src/rqt_sonar_image_view/image_view.cpp
+++ b/src/rqt_sonar_image_view/image_view.cpp
@@ -201,7 +201,7 @@ void ImageView::restoreSettings(const qt_gui_cpp::Settings &plugin_settings,
 
 void ImageView::updateTopicList() {
   QSet<QString> message_types;
-  message_types.insert("acoustic_msgs/ProjectedSonarImage");
+  message_types.insert("marine_acoustic_msgs/ProjectedSonarImage");
 
   QString selected = ui_.topics_combo_box->currentText();
 
@@ -342,7 +342,7 @@ void ImageView::onHideToolbarChanged(bool hide) {
 }
 
 void ImageView::callbackImage(
-    const acoustic_msgs::ProjectedSonarImage::ConstPtr &msg) {
+    const marine_acoustic_msgs::ProjectedSonarImage::ConstPtr &msg) {
   SonarImageMsgInterface ping(msg);
 
   if (ping.data_type() ==


### PR DESCRIPTION
Updates to use current [marine_msgs/marine_acoustic_msgs](https://github.com/apl-ocean-engineering/marine_msgs) [ tag "v2.0.0"](https://github.com/apl-ocean-engineering/marine_msgs/releases/tag/v2.0.0).

* Update `rqt_sonar_image_view.rosinstall`
* Update `package.xml` and `Cmakelists.txt`
* Update include files and namespaces in source files.

I do not currently have a sonar in the water or bagfiles with the new message format, so I am unable to complete any functional testing on this update.

Addresses #6 